### PR TITLE
Propose a focusin action on jquery.priceformat.js

### DIFF
--- a/jquery.priceformat.js
+++ b/jquery.priceformat.js
@@ -265,6 +265,7 @@
       obj.bind('keydown.price_format', key_check);
       obj.bind('keyup.price_format', price_it);
       obj.bind('focusout.price_format', price_it);
+	  obj.bind('focusin.price_format', price_it);
 
       // Clear Prefix and Add Prefix
       if (clearPrefix) {


### PR DESCRIPTION
I propose to add a focusin action on jquery.priceformat.js, exactly on bind the actions section

```
//bind the actions
obj.bind('keydown.price_format', key_check);
obj.bind('keyup.price_format', price_it);
obj.bind('focusout.price_format', price_it);
obj.bind('focusin.price_format', price_it);

```
This is simple, but useful when the project made a calculation and the result of calculation will be automatically put inside a textbox.

Example:
By adding the focusin action like what I proposed, the project just need to add a

`document.getElementById("anyIDforResultTextBox").focus()`

After that, the result of calculation will be following the needed priceformat on the textbox.